### PR TITLE
[BUGFIX] Wrap template around fluid wrapper

### DIFF
--- a/Resources/Private/Templates/CompactView/Index.html
+++ b/Resources/Private/Templates/CompactView/Index.html
@@ -1,4 +1,5 @@
-
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
 
 <div id="bynder-compactview"
      data-language="{language}"
@@ -43,3 +44,5 @@
         }
     });
 </script>
+
+</html>


### PR DESCRIPTION
Some instances have problems using fluid cache where the
variables are not processed into the view as the renderer
processes as flat html.

<img width="359" alt="Rendering" src="https://user-images.githubusercontent.com/2414665/103888434-0796fa80-50e5-11eb-9297-8718f969d701.png">
<hr>
<img width="994" alt="Sourcecode" src="https://user-images.githubusercontent.com/2414665/103888428-05cd3700-50e5-11eb-96fc-bfb999d57e6f.png">
