### PR TITLE
[BUGFIX] Wrap template around fluid cache wrapper

### DIFF
--- a/Resources/Private/Templates/CompactView/Index.html
+++ b/Resources/Private/Templates/CompactView/Index.html
@@ -1,30 +1,35 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
 
+<f:cache.static>
+    <div id="bynder-compactview"
+         data-element=".{element}"
+         data-language="{language}"
+         data-button="Pick a file from Bynder"
+         data-folder="bynder-compactview"
+         data-zindex="300"
+         data-collections="false"
+         data-header="false"
+         data-autoload="true"
+         data-fullScreen="true"
+         data-defaultEnvironment="{apiBaseUrl}"
+         data-button-id="1"
+    ></div>
+</f:cache.static>
 
-<div id="bynder-compactview"
-     data-language="{language}"
-     data-button="Pick a file from Bynder"
-     data-folder="bynder-compactview"
-     data-zindex="300"
-     data-collections="false"
-     data-header="false"
-     data-autoload="true"
-     data-fullScreen="true"
-     data-defaultEnvironment="{apiBaseUrl}"
-     data-button-id="1"
-></div>
 <script src="https://d8ejoa1fys2rk.cloudfront.net/5.0.5/modules/compactview/bynder-compactview-2-latest.js"></script>
 
 
 <div id="importedAssets"></div>
 <script>
-    var element = ".{element}";
+    var container = document.getElementById('bynder-compactview');
     BynderCompactView.open({
         onSuccess: function (selectedAssets) {
             var media = [];
             for (var i = 0; i < selectedAssets.length; i++) {
                 media.push(selectedAssets[i].databaseId);
             }
-            var details = {media: media, 'element': element},
+            var details = {media: media, 'element': container.getAttribute('data-element')},
                 parentDocument = parent.document,
                 contentIframe = parent.document.getElementById('typo3-contentIframe');
 
@@ -36,10 +41,12 @@
         },
         collections: false,
         assetTypes: ['image'],
-        container: document.getElementById('bynder-compactview'),
+        container: container,
         portal: {
-            url: document.getElementById('bynder-compactview').getAttribute('data-defaultEnvironment'),
+            url: container.getAttribute('data-defaultEnvironment'),
             editable: false,
         }
     });
 </script>
+
+</html>


### PR DESCRIPTION
Some instances have problems using fluid cache where the
variables are not processed into the view as the renderer
processes as flat html.

My assumption is that its only applicable for specific environments..

<img width="359" alt="Rendering" src="https://user-images.githubusercontent.com/2414665/103888434-0796fa80-50e5-11eb-9297-8718f969d701.png">
<hr>
<img width="994" alt="Sourcecode" src="https://user-images.githubusercontent.com/2414665/103888428-05cd3700-50e5-11eb-96fc-bfb999d57e6f.png">
