### PR TITLE
[TASK] Add extension key to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
 		},
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
-			"web-dir": ".Build/Web"
+			"web-dir": ".Build/Web",
+			"extension-key": "bynder"
+
 		}
 	}
 }


### PR DESCRIPTION
Composer Warning: TYPO3 Extension Package "beechit/bynder", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)