### PR TITLE
[BUGFIX] Wrap element into format.raw

### DIFF
--- a/Resources/Private/Templates/CompactView/Index.html
+++ b/Resources/Private/Templates/CompactView/Index.html
@@ -20,8 +20,8 @@
 
 <div id="importedAssets"></div>
 <script>
-    var container = document.getElementById('bynder-compactview');  
-    var element = ".{element}";
+    var container = document.getElementById('bynder-compactview');
+    var element = '.<f:format.raw>{element}</f:format.raw>';
     BynderCompactView.open({
         onSuccess: function (selectedAssets) {
             var media = [];


### PR DESCRIPTION
When the fluid goes through the parser, it (sometimes) sees the <script> `{}` as javascript attributes and not fluid variable.

Added f:format.raw to force parsing of fluid content;

See: https://docs.typo3.org/m/typo3/guide-extbasefluid/master/en-us/Fluid/ThingsToKnow/JsAndInline.html